### PR TITLE
Added method to request invoice as XML

### DIFF
--- a/lib/economic/invoice.rb
+++ b/lib/economic/invoice.rb
@@ -68,5 +68,11 @@ module Economic
 
       Base64.decode64(response)
     end
+
+    def xml
+      request(:get_oio_xml, {
+        "invoiceHandle" => handle.to_hash
+      })
+    end
   end
 end


### PR DESCRIPTION
By adding this method, it is possible to easily retrieve data that is otherwise unavailable through the API, such as the KID number of an invoice.