### PR TITLE
Initial support for X-EconomicAppIdentifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,10 @@ Usage example
 -------------
 
     economic = Economic::Session.new
-    economic.connect_with_credentials(123456, 'API', 'passw0rd')
+
+    # After 16 November 2015, you must supply an 'Application ID' with #connect_with_credentials
+    # As described here: http://techtalk.e-conomic.com/e-conomic-soap-api-now-requires-you-to-specify-a-custom-x-economicappidentifier-header/
+    economic.connect_with_credentials(123456, 'API', 'passw0rd', 'my awesome integration v1.0.0')
 
     # Or connect using a Private app ID and an access ID provided by the "Grant Access"
     # As described here: http://www.e-conomic.com/developer/tutorials

--- a/lib/economic/endpoint.rb
+++ b/lib/economic/endpoint.rb
@@ -8,6 +8,10 @@ class Economic::Endpoint
   def_delegator "client.globals", :log_level, :log_level=
   def_delegator "client.globals", :log, :log=
 
+  def initialize(app_identifier = nil)
+    @app_identifier = app_identifier
+  end
+
   # Invokes soap_action on the API endpoint with the given data.
   #
   # Returns a Hash with the resulting response from the endpoint as a Hash.
@@ -35,6 +39,7 @@ class Economic::Endpoint
       wsdl      File.expand_path(File.join(File.dirname(__FILE__), "economic.wsdl"))
       log       false
       log_level :info
+      headers({'X-EconomicAppIdentifier' => @app_identifier }) if @app_identifier
     end
   end
 

--- a/lib/economic/endpoint.rb
+++ b/lib/economic/endpoint.rb
@@ -8,6 +8,14 @@ class Economic::Endpoint
   def_delegator "client.globals", :log_level, :log_level=
   def_delegator "client.globals", :log, :log=
 
+  # Create a new Endpoint
+  #
+  # Economic::Session uses this internally
+  #
+  # ==== Attributes
+  #
+  # * +app_identifier+ - A string identifiying your application, as described in http://techtalk.e-conomic.com/e-conomic-soap-api-now-requires-you-to-specify-a-custom-x-economicappidentifier-header/
+  #
   def initialize(app_identifier = nil)
     @app_identifier = app_identifier
   end

--- a/lib/economic/session.rb
+++ b/lib/economic/session.rb
@@ -19,6 +19,15 @@ module Economic
       yield endpoint if block_given?
     end
 
+    # Connect/authenticate with an API token and app id
+    #
+    # Reference: http://techtalk.e-conomic.com/why-were-implementing-a-new-api-connection-model/
+    #
+    # ==== Attributes
+    #
+    # * +private_app_id+ - The App ID created in your developer agreement
+    # * +access_id+ - The Access ID or token for your App ID
+    #
     def connect_with_token(private_app_id, access_id)
       endpoint.call(
         :connect_with_token,
@@ -31,6 +40,15 @@ module Economic
       end
     end
 
+    # Connect/authenticate with credentials
+    #
+    # ==== Attributes
+    #
+    # * +agreement_number+ - your economic agreement number
+    # * +user_name+ - your username
+    # * +password+ - your passsword
+    # * +app_identifier+ - A string identifiying your application, as described in http://techtalk.e-conomic.com/e-conomic-soap-api-now-requires-you-to-specify-a-custom-x-economicappidentifier-header/
+    #
     def connect_with_credentials(agreement_number, user_name, password, app_identifier = nil)
       self.app_identifier = app_identifier if app_identifier
 

--- a/lib/economic/session.rb
+++ b/lib/economic/session.rb
@@ -8,13 +8,14 @@ module Economic
 
     def_delegators :endpoint, :logger=, :log_level=, :log=
 
-    attr_accessor :agreement_number, :user_name, :password
+    attr_accessor :agreement_number, :user_name, :password, :app_identifier
     attr_reader :authentication_token
 
-    def initialize(agreement_number = nil, user_name = nil, password = nil)
+    def initialize(agreement_number = nil, user_name = nil, password = nil, app_identifier = nil)
       self.agreement_number = agreement_number
       self.user_name = user_name
       self.password = password
+      self.app_identifier = app_identifier
       yield endpoint if block_given?
     end
 
@@ -30,7 +31,9 @@ module Economic
       end
     end
 
-    def connect_with_credentials(agreement_number, user_name, password)
+    def connect_with_credentials(agreement_number, user_name, password, app_identifier = nil)
+      self.app_identifier = app_identifier if app_identifier
+
       endpoint.call(
         :connect,
         {
@@ -46,7 +49,7 @@ module Economic
     # Authenticates with E-conomic using credentials
     # Assumes ::new was called with credentials as arguments.
     def connect
-      connect_with_credentials(self.agreement_number, self.user_name, self.password)
+      connect_with_credentials(self.agreement_number, self.user_name, self.password, self.app_identifier)
     end
 
     # Provides access to the DebtorContacts
@@ -121,7 +124,7 @@ module Economic
 
     # Returns the SOAP endpoint to connect to
     def endpoint
-      @endpoint ||= Economic::Endpoint.new
+      @endpoint ||= Economic::Endpoint.new(app_identifier)
     end
 
     private

--- a/spec/economic/endpoint_spec.rb
+++ b/spec/economic/endpoint_spec.rb
@@ -86,4 +86,12 @@ describe Economic::Endpoint do
       subject.logger = logger
     end
   end
+
+  describe "app identifier configuration" do
+    let(:app_id) { 'my awesome app v.4.0.9-beta-rc1' }
+
+    it "can be instantiated with an app_identifier" do
+      expect(Economic::Endpoint.new(app_id).client).to be_instance_of(::Savon::Client)
+    end
+  end
 end

--- a/spec/economic/session_spec.rb
+++ b/spec/economic/session_spec.rb
@@ -14,6 +14,11 @@ describe Economic::Session do
         expect(subject.user_name).to eq('api')
         expect(subject.password).to eq('passw0rd')
       end
+
+      it "can also store an app_id" do
+        session = Economic::Session.new *credentials, 'app_id'
+        expect(session.app_identifier).to eq('app_id')
+      end
     end
 
     it "yields the endpoint if a block is given" do


### PR DESCRIPTION
So here's a somewhat hacky solution.

I couldn't easily see how to test if request headers are set when mocking requests, but I have run this on a production batch job that uses `connect_with_credentials` and it does work for me.